### PR TITLE
events-example: First big pass at the events example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SynqlyPythonClient"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 readme = "README.md"
 authors = []

--- a/src/engine/resources/ocsf/resources/accountchange/resources/objects/types/session.py
+++ b/src/engine/resources/ocsf/resources/accountchange/resources/objects/types/session.py
@@ -25,7 +25,7 @@ class Session(pydantic.BaseModel):
     is_remote: typing.Optional[bool] = pydantic.Field(description="The indication of whether the session is remote.")
     issuer: typing.Optional[str] = pydantic.Field(description="The identifier of the session issuer.")
     uid: typing.Optional[str] = pydantic.Field(description="The unique identifier of the session.")
-    uuid: typing.Optional[uuid.UUID] = pydantic.Field(description="The universally unique identifier of the session.")
+    uuid: typing.Optional[uuid.UUID(as_uuid=True)] = pydantic.Field(description="The universally unique identifier of the session.")
 
     def json(self, **kwargs: typing.Any) -> str:
         kwargs_with_defaults: typing.Any = {"by_alias": True, "exclude_unset": True, **kwargs}


### PR DESCRIPTION
Not currently working due to issue importing engine - the OCSF types  have a folder named 'class'

Author: Alexi Kessler <alexi@synqly.com>