### PR TITLE
python-sdk-readme: remove siem-connector section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,61 +77,6 @@ Note that installing a pip package over SSH requires a username be set, thus we 
 pip3 install git+ssh://git@github.com/Synqly/python-sdk.git
 ```
 
-## Requirements.txt
-
-Adding `github.com/Synqly/python-sdk` to a Python project's `requirements.txt` is very similar to the command line package installations above. The `examples/siem-connector/requirements.txt` file contains examples of how to install the repository using either a Github PAT or an SSH key. 
-
-# Siem Connector Example
-
-The `examples` directory of this repository contains example implementations that demonstrate how to incorporate Synqly SDKs into a Python application.
-
-This section acts as supporting documentation for the sample program in `examples/siem-connector`. The `siem-connector` example demonstrates how to use the Synqly's SIEM Connector to send events to a SIEM Provider (Splunk) from within a multi-tenant application. 
-
-The `siem-connector` example will:
-
-- Define multiple tenants in a sample application
-- Define an `Integration` for each tenant (using Splunk as the target SIEM Provider)
-- Run a background job to simulate load for each tenant
-- Send events from the background job to Synqly
-- Demonstrate that events are sent in OCSF format and transformed by Synqly before being forwarded to the target SIEM Provider.
-
-
-## Prerequisites
-
-- A [Synqly](https://synqly.com) `Organization`
-- Your Synqly Organization ID and API Token
-- Python 3
-- A Splunk account -- [sign up for a free trial](https://www.splunk.com/en_us/download.html)
-- A Splunk HTTP Event Collector (HEC) endpoint and API token -- [create a new HEC token](https://docs.splunk.com/Documentation/Splunk/8.1.3/Data/UsetheHTTPEventCollector#Create_an_Event_Collector_token)
-
-## Setup and Run
-
-1. Install `github.com/Synqly/python-sdk` and its dependencies by running the following command:
-
-    ```bash
-    pip3 install -r examples/siem-connector/requirements.txt
-    ```
-
-2. The example depends on environment variables to connect to Synqly and Splunk. To allow the sample program to connect to Synqly, set the following environment variables to your Organization ID and API Token values.
-
-    ```bash
-    export SYNQLY_ORG_ID=<your-org-id>
-    export SYNQLY_API_TOKEN=<your-api-token>
-    ```
-
-3. Access to Splunk is also configured via environment variable. Set the following variables in your terminal:
-
-    ```bash
-    export SPLUNK_URL=https://<your-org>.splunkcloud.com:8088/services/collector/event
-    export SPLUNK_TOKEN=<your-splunk-token>
-    ```
-
-4. Run the example
-    ```bash
-    python3 examples/siem-connector/main.py
-    ```
-
-
 # Local Development
 
 While the files under `/src` are auto-generated, it can sometimes be useful to install a local copy of the SDK in order to debug issues such as type mismatches. The following command will install the local version of `SynqlyPythonClient`, overriding the upstream repository. 


### PR DESCRIPTION
Now that we have multiple example, we can put instructions for individual examples in the example directories.

Author: Alexi Kessler <alexi@synqly.com>