### PR TITLE
python-sdk: pydantic 2 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "SynqlyPythonClient"
-version = "0.1.65"
+version = "0.1.66"
 description = ""
 readme = "README.md"
 authors = []
@@ -12,7 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 httpx = ">=0.21.2"
-pydantic = ">= 1.9.2, < 2"
+pydantic = ">= 1.9.2"
 
 [tool.poetry.dev-dependencies]
 mypy = "0.971"


### PR DESCRIPTION
- Result of upgrading fern python generator to 0.11.10
- Also remove upperbound from pydantic req in pyproject.toml

Author: Alexi Kessler <alexi@synqly.com>